### PR TITLE
Add customizable multi-goal tracking

### DIFF
--- a/ExtraMile+/ContentView.swift
+++ b/ExtraMile+/ContentView.swift
@@ -73,7 +73,6 @@ struct ContentView: View {
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("ExtraMile")
         }
-        .ignoresSafeArea(.all)
         .sheet(isPresented: $showGoalCreator) {
             GoalEditorView()
         }

--- a/ExtraMile+/ContentView.swift
+++ b/ExtraMile+/ContentView.swift
@@ -321,6 +321,8 @@ struct AddNewEntry: View {
 }
 
 struct GoalProgressRow: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let goal: GoalModel
     let milesCompleted: Double
     let progress: Double
@@ -349,65 +351,127 @@ struct GoalProgressRow: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 20) {
             HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 8) {
                     Text(goal.title)
-                        .font(.headline)
+                        .font(.title3.weight(.semibold))
                     Text(goal.intervalDescription)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.yellow.opacity(0.85))
                     Text(goal.kind.displayName)
-                        .font(.caption2)
+                        .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
                 }
 
                 Spacer()
 
-                GoalProgressRing(progress: clampedProgress, label: progressText)
+                GoalProgressRing(progress: clampedProgress, label: progressText, diameter: 88, lineWidth: 9)
             }
 
+            Text("\(progressText) Complete")
+                .font(.title2.weight(.bold))
+                .foregroundStyle(.yellow)
+                .contentTransition(.numericText())
+
             RunnerProgressTrack(progress: clampedProgress)
+                .padding(.vertical, 4)
 
-            VStack(alignment: .leading, spacing: 12) {
-                GoalMetricRow(icon: "figure.run", title: "Completed", value: mileageSummary)
+            VStack(spacing: 12) {
+                HStack(spacing: 12) {
+                    GoalMetricRow(icon: "figure.run", title: "Completed", value: mileageSummary, valueTint: primaryMetricTint)
+                        .metricContainer()
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-                GoalMetricRow(icon: "flag.checkered", title: "Remaining", value: remainingMiles)
+                    GoalMetricRow(icon: "flag.checkered", title: "Remaining", value: remainingMiles, valueTint: primaryMetricTint)
+                        .metricContainer()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
 
                 GoalMetricRow(
                     icon: "flame.fill",
                     title: "Streak",
                     value: streakText,
-                    valueTint: streak > 0 ? .orange : .secondary.opacity(0.8)
+                    valueTint: streakTint
                 )
+                .metricContainer(fullWidth: true)
             }
 
             if clampedProgress >= 1 {
                 Label("Goal complete! Keep the streak alive.", systemImage: "sparkles")
-                    .font(.caption2)
+                    .font(.caption2.weight(.semibold))
                     .foregroundStyle(.yellow)
+                    .padding(.top, 4)
             }
         }
-        .padding(20)
+        .padding(24)
         .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(Color(.secondarySystemBackground))
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .fill(cardBackground)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 20, style: .continuous)
-                        .stroke(Color(.systemGray4).opacity(0.35))
+                    RoundedRectangle(cornerRadius: 26, style: .continuous)
+                        .stroke(borderColor, lineWidth: 1)
                 )
         )
+        .shadow(color: shadowColor, radius: 18, x: 0, y: colorScheme == .dark ? 12 : 8)
+    }
+
+    private var cardBackground: LinearGradient {
+        if colorScheme == .dark {
+            return LinearGradient(
+                colors: [
+                    Color(.sRGB, red: 0.08, green: 0.08, blue: 0.08, opacity: 1),
+                    Color(.sRGB, red: 0.12, green: 0.12, blue: 0.12, opacity: 1),
+                    Color(.sRGB, red: 0.16, green: 0.16, blue: 0.16, opacity: 1)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        }
+
+        return LinearGradient(
+            colors: [
+                Color(.sRGB, red: 0.99, green: 0.99, blue: 0.97, opacity: 1),
+                Color(.sRGB, red: 0.97, green: 0.97, blue: 0.94, opacity: 1),
+                Color(.sRGB, red: 0.94, green: 0.94, blue: 0.9, opacity: 1)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var borderColor: Color {
+        colorScheme == .dark ? Color.yellow.opacity(0.15) : Color.black.opacity(0.08)
+    }
+
+    private var shadowColor: Color {
+        colorScheme == .dark ? Color.black.opacity(0.35) : Color.black.opacity(0.1)
+    }
+
+    private var primaryMetricTint: Color {
+        colorScheme == .dark ? .white : .black
+    }
+
+    private var streakTint: Color {
+        if streak > 0 {
+            return .orange
+        }
+        return colorScheme == .dark ? Color.white.opacity(0.6) : Color.black.opacity(0.45)
     }
 }
 
 struct GoalProgressRing: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let progress: Double
     let label: String
+    var diameter: CGFloat = 74
+    var lineWidth: CGFloat = 8
 
     var body: some View {
         ZStack {
             Circle()
-                .strokeBorder(Color(.systemGray4).opacity(0.4), lineWidth: 8)
+                .strokeBorder(trackColor, lineWidth: lineWidth)
             Circle()
                 .trim(from: 0, to: progress)
                 .stroke(
@@ -415,18 +479,24 @@ struct GoalProgressRing: View {
                         colors: [.yellow.opacity(0.9), .yellow, .orange.opacity(0.9)],
                         center: .center
                     ),
-                    style: StrokeStyle(lineWidth: 8, lineCap: .round)
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
                 )
                 .rotationEffect(.degrees(-90))
             Text(label)
                 .font(.caption.monospacedDigit())
                 .bold()
         }
-        .frame(width: 74, height: 74)
+        .frame(width: diameter, height: diameter)
+    }
+
+    private var trackColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.1)
     }
 }
 
 struct GoalMetricRow: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let icon: String
     let title: String
     let value: String
@@ -441,19 +511,23 @@ struct GoalMetricRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(titleColor)
                 Text(value)
                     .font(.callout.weight(.semibold))
                     .foregroundStyle(valueTint)
             }
         }
     }
+
+    private var titleColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.6) : Color.black.opacity(0.6)
+    }
 }
 
 struct RunnerProgressTrack: View {
     let progress: Double
 
-    private let trackLength = 50
+    private let trackLength = 48
 
     private var clampedProgress: Double {
         min(max(progress, 0), 1)
@@ -479,6 +553,33 @@ struct RunnerProgressTrack: View {
         .font(.caption.monospaced())
         .foregroundStyle(.yellow)
         .animation(.easeInOut(duration: 0.4), value: leadingDots)
+    }
+}
+
+private extension View {
+    func metricContainer(fullWidth: Bool = false) -> some View {
+        modifier(MetricContainerModifier(fullWidth: fullWidth))
+    }
+}
+
+private struct MetricContainerModifier: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var fullWidth: Bool
+
+    func body(content: Content) -> some View {
+        let background = colorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.05)
+        let border = colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.06)
+
+        return content
+            .padding(.vertical, 10)
+            .padding(.horizontal, 12)
+            .background(background, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(border, lineWidth: 1)
+            )
+            .frame(maxWidth: fullWidth ? .infinity : nil, alignment: .leading)
     }
 }
 

--- a/ExtraMile+/ContentView.swift
+++ b/ExtraMile+/ContentView.swift
@@ -8,57 +8,25 @@
 import SwiftUI
 import Firebase
 import FirebaseAuth
+import Observation
 
 struct ContentView: View {
     @Environment(FirebaseManager.self) private var fbManager
+    @Environment(GoalStore.self) private var goalStore
     @AppStorage("loginStatus") private var loginStatus: Bool = false
     @State private var showNewEntry = false
     @State private var showHistory = false
-    @State private var count = 0
-    @State private var moveMan = false
-    @State private var goalAmount = 365
-    
-    private var currentMiles: Double {
-        return fbManager.runs.reduce(0.00) { $0 + $1.miles}
-    }
-    
+    @State private var showGoalCreator = false
+
     var body: some View {
         NavigationStack {
-            VStack(spacing: 50) {
-                Text("\((String(format: "%.2f", calcPercent(currentMiles, goalAmount) * 100)))% Complete")
-                    .font(.title3)
-                    .bold()
-                    .animation(.default)
-                    .contentTransition(.numericText())
-                   
-                HStack {
-                    Text(String(repeating: ".", count: calcDistance(currentMiles, goalAmount))).foregroundStyle(.yellow) + Text(Image(systemName: "figure.run")).foregroundStyle(.yellow) + Text(String(repeating: ".", count: 50-calcDistance(currentMiles, goalAmount))).foregroundStyle(.yellow)
-                    + Text(Image(systemName: "rectangle.checkered"))
-                        .foregroundStyle(.yellow)
+            ScrollView {
+                VStack(spacing: 40) {
+                    goalSection
+                    recentRunsSection
                 }
-                
-                Text("\(String(format: "%.2f", currentMiles))mi of 365mi")
-                    .font(.headline)
-                    .contentTransition(.numericText())
-                
-                VStack(spacing: 20){
-                    HStack {
-                        Text("Recent")
-                        Spacer()
-                    }.font(.title2).bold()
-                    
-                    VStack(spacing: 10) {
-                        ForEach(fbManager.runs) { run in
-                            HStack(spacing: 50) {
-                                Text("\(String(format: "%.2f", run.miles)) mi")
-                                Text("\(run.time.value(for: .hour) ?? 0)hr \(run.time.value(for: .minute) ?? 0)min")
-                                Text("\(calculatePace(run.time.value(for: .hour) ?? 0, run.time.value(for: .minute) ?? 0, run.time.value(for: .second) ?? 0, run.miles)) mph")
-                            }.font(.headline)
-                        }
-                    }
-                }
+                .padding()
             }
-            .padding()
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
@@ -72,7 +40,7 @@ struct ContentView: View {
                         HistoryView(profileId: Auth.auth().currentUser?.uid ?? "")
                     })
                 }
-                
+
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         showNewEntry.toggle()
@@ -84,7 +52,7 @@ struct ContentView: View {
                         AddNewEntry()
                     }
                 }
-                
+
                 ToolbarItem {
                     Button {
                         do {
@@ -104,29 +72,150 @@ struct ContentView: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("ExtraMile")
-        }.ignoresSafeArea(.all)
-        
+        }
+        .ignoresSafeArea(.all)
+        .sheet(isPresented: $showGoalCreator) {
+            GoalEditorView()
+        }
     }
-    
-    func calcDistance(_ currentMiles: Double, _ goalAmount: Int) -> Int {
-        let percent = Double(currentMiles) / Double(goalAmount)
-        return Int(round(50.0 * Double(percent)))
+
+    private var goalSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Goals")
+                        .font(.title2)
+                        .bold()
+                    Text("Create yearly, monthly, or race goals with personalized progress.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button {
+                    showGoalCreator = true
+                } label: {
+                    Label("Add Goal", systemImage: "plus.circle.fill")
+                        .labelStyle(.titleAndIcon)
+                        .font(.callout)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.yellow)
+                .foregroundStyle(.black)
+            }
+
+            if goalStore.goals.isEmpty {
+                Text("You haven't added any goals yet. Tap **Add Goal** to build yearly, monthly, or race targets that match your training.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Color(.systemGray6))
+                    )
+            } else {
+                LazyVStack(spacing: 16) {
+                    ForEach(goalStore.goals) { goal in
+                        GoalProgressRow(
+                            goal: goal,
+                            milesCompleted: miles(for: goal),
+                            progress: progress(for: goal),
+                            streak: streak(for: goal)
+                        )
+                        .swipeActions {
+                            Button(role: .destructive) {
+                                goalStore.removeGoal(goal)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
-    
-    func calcPercent(_ currentMiles: Double, _ goalAmount: Int) -> Double {
-        return currentMiles / Double(goalAmount)
+
+    private var recentRunsSection: some View {
+        VStack(spacing: 20) {
+            HStack {
+                Text("Recent")
+                Spacer()
+            }
+            .font(.title2)
+            .bold()
+
+            VStack(spacing: 10) {
+                ForEach(fbManager.runs) { run in
+                    HStack(spacing: 50) {
+                        Text("\(String(format: "%.2f", run.miles)) mi")
+                        Text("\(run.time.value(for: .hour) ?? 0)hr \(run.time.value(for: .minute) ?? 0)min")
+                        Text("\(calculatePace(run.time.value(for: .hour) ?? 0, run.time.value(for: .minute) ?? 0, run.time.value(for: .second) ?? 0, run.miles)) mph")
+                    }
+                    .font(.headline)
+                }
+            }
+        }
     }
-    
+
+    private func miles(for goal: GoalModel) -> Double {
+        fbManager.runs
+            .filter { goal.contains(date: $0.date) }
+            .reduce(0.0) { $0 + $1.miles }
+    }
+
+    private func progress(for goal: GoalModel) -> Double {
+        guard goal.targetMiles > 0 else { return 0 }
+        let milesCompleted = miles(for: goal)
+        return milesCompleted / goal.targetMiles
+    }
+
+    private func streak(for goal: GoalModel) -> Int {
+        let calendar = Calendar.current
+        let start = calendar.startOfDay(for: goal.startDate)
+        let comparisonEnd = calendar.startOfDay(for: min(goal.endDate, Date()))
+
+        if comparisonEnd < start {
+            return 0
+        }
+
+        let runDates = Set(
+            fbManager.runs
+                .filter { goal.contains(date: $0.date) }
+                .map { calendar.startOfDay(for: $0.date) }
+        )
+
+        if runDates.isEmpty {
+            return 0
+        }
+
+        var currentDate = comparisonEnd
+        var streakCount = 0
+
+        while currentDate >= start {
+            if runDates.contains(currentDate) {
+                streakCount += 1
+                guard let previousDay = calendar.date(byAdding: .day, value: -1, to: currentDate) else { break }
+                currentDate = previousDay
+            } else {
+                break
+            }
+        }
+
+        return streakCount
+    }
+
     func calculatePace(_ hour: Int, _ min: Int, _ sec: Int, _ miles: Double) -> String {
         let totalTimeInSeconds = Double(hour * 3600 + min * 60 + sec)
         let pacePerMile = totalTimeInSeconds / miles
         return formatTime(seconds: Int(pacePerMile))
     }
-    
+
     func formatTime(hours: Int, minutes: Int, seconds: Int) -> String {
         return String(format: "%02d:%02d", minutes, seconds)
     }
-    
+
     func formatTime(seconds: Int) -> String {
         let hours = seconds / 3600
         let minutes = (seconds % 3600) / 60
@@ -137,6 +226,8 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environment(FirebaseManager())
+        .environment(GoalStore())
 }
 
 struct AddNewEntry: View {
@@ -148,12 +239,12 @@ struct AddNewEntry: View {
     @State private var speed = 0.0
     @State private var pace = ""
     @State private var isShowingAlert = false
-    
+
     let placeholder: String = "Miles"
-    
+
     @State private var width = CGFloat.zero
     @State private var labelWidth = CGFloat.zero
-    
+
     var body: some View {
         VStack(spacing: 20) {
             TextField("Miles", text: $miles)
@@ -182,29 +273,29 @@ struct AddNewEntry: View {
                 }
                 .overlay( GeometryReader { geo in Color.clear.onAppear { width = geo.size.width }})
                 .padding(20)
-            
+
             TimePickerView(seconds: $time)
-            
+
             DatePicker("Date:", selection: $date)
                 .padding(20)
-            
+
             Button {
                 if miles == "" || miles == "0" || miles == "0.0"{
                     isShowingAlert = true
                 } else {
                     fbManager.addData(miles: Double(miles) ?? 0.0, time: time, date: date, profileId: Auth.auth().currentUser?.uid ?? "")
-                    
+
                     Task {
                         await fbManager.fetchData(profileId: Auth.auth().currentUser?.uid ?? "")
                     }
                     dismiss()
                 }
 
-                
+
             } label: {
                 Text("Add Run")
                     .frame(maxWidth: 350)
-                    
+
             }
             .foregroundStyle(.primary)
             .buttonStyle(.bordered)
@@ -212,20 +303,321 @@ struct AddNewEntry: View {
             .alert("Please enter miles", isPresented: $isShowingAlert) {
                         Button("OK", role: .cancel) { isShowingAlert = false }
             }
-            
+
         }
     }
-    
+
     func convertSecondsToDateTime(_ seconds: Int) -> DateComponents {
         let hours = seconds / 3600
         let minutes = (seconds % 3600) / 60
         let seconds = seconds % 60
-        
+
         var dateComponents = DateComponents()
         dateComponents.hour = hours
         dateComponents.minute = minutes
         dateComponents.second = seconds
-        
+
         return dateComponents
+    }
+}
+
+struct GoalProgressRow: View {
+    let goal: GoalModel
+    let milesCompleted: Double
+    let progress: Double
+    let streak: Int
+
+    private var progressText: String {
+        let percent = progress * 100
+        return String(format: "%.0f%%", percent)
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            GoalProgressRing(progress: progress, label: progressText)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(goal.title)
+                    .font(.headline)
+                Text(goal.intervalDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(goal.kind.displayName)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Label("\(String(format: "%.2f", milesCompleted)) / \(String(format: "%.2f", goal.targetMiles)) mi", systemImage: "figure.run")
+                        .font(.subheadline)
+                    Label("\(streak) day streak", systemImage: "flame.fill")
+                        .font(.caption)
+                        .foregroundStyle(streak > 0 ? .orange : .secondary)
+                }
+
+                if progress >= 1 {
+                    Text("Goal complete! Keep the streak alive.")
+                        .font(.caption2)
+                        .foregroundStyle(.yellow)
+                        .padding(.top, 4)
+                }
+            }
+
+            Spacer()
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.systemGray6))
+        )
+    }
+}
+
+struct GoalProgressRing: View {
+    let progress: Double
+    let label: String
+
+    private var normalizedProgress: Double {
+        min(max(progress, 0), 1)
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color(.systemGray5), lineWidth: 10)
+            Circle()
+                .trim(from: 0, to: normalizedProgress)
+                .stroke(
+                    .linearGradient(
+                        colors: [.yellow.opacity(0.8), .yellow],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ),
+                    style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+            Text(label)
+                .font(.caption)
+                .bold()
+        }
+        .frame(width: 80, height: 80)
+    }
+}
+
+enum GoalKind: String, CaseIterable, Codable, Identifiable {
+    case yearly
+    case monthly
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .yearly:
+            return "Yearly Goal"
+        case .monthly:
+            return "Monthly Goal"
+        case .custom:
+            return "Race Goal"
+        }
+    }
+
+    func defaultTitle(for startDate: Date, endDate: Date) -> String {
+        let calendar = Calendar.current
+        switch self {
+        case .yearly:
+            let year = calendar.component(.year, from: startDate)
+            return "\(year) Mileage"
+        case .monthly:
+            let formatter = DateFormatter()
+            formatter.dateFormat = "LLLL yyyy"
+            return "\(formatter.string(from: startDate)) Mileage"
+        case .custom:
+            return "Race Goal"
+        }
+    }
+
+    func defaultDateRange(from referenceDate: Date = Date(), calendar: Calendar = .current) -> (start: Date, end: Date) {
+        switch self {
+        case .yearly:
+            let components = calendar.dateComponents([.year], from: referenceDate)
+            let start = calendar.date(from: components) ?? referenceDate
+            let end = calendar.date(byAdding: DateComponents(year: 1, second: -1), to: start) ?? referenceDate
+            return (start, end)
+        case .monthly:
+            let components = calendar.dateComponents([.year, .month], from: referenceDate)
+            let start = calendar.date(from: components) ?? referenceDate
+            let end = calendar.date(byAdding: DateComponents(month: 1, second: -1), to: start) ?? referenceDate
+            return (start, end)
+        case .custom:
+            return (referenceDate, referenceDate)
+        }
+    }
+}
+
+struct GoalModel: Identifiable, Codable, Equatable {
+    var id: UUID = UUID()
+    var title: String
+    var targetMiles: Double
+    var kind: GoalKind
+    var startDate: Date
+    var endDate: Date
+
+    func contains(date: Date, calendar: Calendar = .current) -> Bool {
+        let normalizedDate = calendar.startOfDay(for: date)
+        let start = calendar.startOfDay(for: startDate)
+        let end = calendar.startOfDay(for: endDate)
+        return normalizedDate >= start && normalizedDate <= end
+    }
+
+    var intervalDescription: String {
+        let formatter = DateIntervalFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: startDate, to: endDate)
+    }
+}
+
+@Observable
+final class GoalStore {
+    private(set) var goals: [GoalModel] = []
+    private let storageKey = "storedGoals"
+
+    init() {
+        loadGoals()
+    }
+
+    func addGoal(_ goal: GoalModel) {
+        goals.append(goal)
+        sortGoals()
+        saveGoals()
+    }
+
+    func removeGoal(_ goal: GoalModel) {
+        goals.removeAll { $0.id == goal.id }
+        saveGoals()
+    }
+
+    private func sortGoals() {
+        goals.sort { $0.startDate < $1.startDate }
+    }
+
+    private func saveGoals() {
+        do {
+            let data = try JSONEncoder().encode(goals)
+            UserDefaults.standard.set(data, forKey: storageKey)
+        } catch {
+            print("Failed to save goals: \(error.localizedDescription)")
+        }
+    }
+
+    private func loadGoals() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else { return }
+        do {
+            goals = try JSONDecoder().decode([GoalModel].self, from: data)
+            sortGoals()
+        } catch {
+            print("Failed to load goals: \(error.localizedDescription)")
+        }
+    }
+}
+
+struct GoalEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(GoalStore.self) private var goalStore
+
+    @State private var title: String = ""
+    @State private var targetMiles: String = ""
+    @State private var kind: GoalKind = .yearly
+    @State private var startDate: Date
+    @State private var endDate: Date
+
+    init() {
+        let defaults = GoalKind.yearly.defaultDateRange()
+        _startDate = State(initialValue: defaults.start)
+        _endDate = State(initialValue: defaults.end)
+    }
+
+    private var isSaveDisabled: Bool {
+        guard let miles = Double(targetMiles), miles > 0 else { return true }
+        return startDate > endDate
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Goal Details") {
+                    TextField("Goal title", text: $title)
+                    Picker("Type", selection: $kind) {
+                        ForEach(GoalKind.allCases) { kind in
+                            Text(kind.displayName).tag(kind)
+                        }
+                    }
+                    TextField("Target miles", text: $targetMiles)
+                        .keyboardType(.decimalPad)
+                }
+
+                Section("Schedule") {
+                    DatePicker("Start", selection: $startDate, displayedComponents: .date)
+                    DatePicker("End", selection: $endDate, in: startDate..., displayedComponents: .date)
+                }
+
+                Section("Preview") {
+                    let previewGoal = GoalModel(title: previewTitle, targetMiles: Double(targetMiles) ?? 0, kind: kind, startDate: startDate, endDate: endDate)
+                    GoalProgressRow(goal: previewGoal, milesCompleted: 0, progress: 0, streak: 0)
+                        .allowsHitTesting(false)
+                }
+            }
+            .navigationTitle("New Goal")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        saveGoal()
+                    }
+                    .disabled(isSaveDisabled)
+                }
+            }
+            .onChange(of: kind) { _, newKind in
+                if newKind != .custom {
+                    let defaults = newKind.defaultDateRange(from: startDate)
+                    startDate = defaults.start
+                    endDate = defaults.end
+                }
+            }
+            .onChange(of: startDate) { _, newValue in
+                if kind != .custom {
+                    let defaults = kind.defaultDateRange(from: newValue)
+                    startDate = defaults.start
+                    endDate = defaults.end
+                } else if endDate < newValue {
+                    endDate = newValue
+                }
+            }
+        }
+    }
+
+    private var previewTitle: String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return kind.defaultTitle(for: startDate, endDate: endDate)
+        }
+        return trimmed
+    }
+
+    private func saveGoal() {
+        guard let miles = Double(targetMiles), miles > 0 else { return }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let newGoal = GoalModel(
+            title: trimmed.isEmpty ? kind.defaultTitle(for: startDate, endDate: endDate) : trimmed,
+            targetMiles: miles,
+            kind: kind,
+            startDate: startDate,
+            endDate: endDate
+        )
+        goalStore.addGoal(newGoal)
+        dismiss()
     }
 }

--- a/ExtraMile+/ContentView.swift
+++ b/ExtraMile+/ContentView.swift
@@ -326,49 +326,76 @@ struct GoalProgressRow: View {
     let progress: Double
     let streak: Int
 
+    private var clampedProgress: Double {
+        min(max(progress, 0), 1)
+    }
+
     private var progressText: String {
-        let percent = progress * 100
+        let percent = clampedProgress * 100
         return String(format: "%.0f%%", percent)
     }
 
+    private var mileageSummary: String {
+        "\(String(format: "%.2f", milesCompleted)) of \(String(format: "%.2f", goal.targetMiles)) mi"
+    }
+
+    private var remainingMiles: String {
+        let remaining = max(goal.targetMiles - milesCompleted, 0)
+        return "\(String(format: "%.2f", remaining)) mi to go"
+    }
+
+    private var streakText: String {
+        streak == 1 ? "1 day streak" : "\(streak) day streak"
+    }
+
     var body: some View {
-        HStack(alignment: .top, spacing: 16) {
-            GoalProgressRing(progress: progress, label: progressText)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text(goal.title)
-                    .font(.headline)
-                Text(goal.intervalDescription)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(goal.kind.displayName)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-
-                RunnerProgressTrack(progress: progress)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Label("\(String(format: "%.2f", milesCompleted)) / \(String(format: "%.2f", goal.targetMiles)) mi", systemImage: "figure.run")
-                        .font(.subheadline)
-                    Label("\(streak) day streak", systemImage: "flame.fill")
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(goal.title)
+                        .font(.headline)
+                    Text(goal.intervalDescription)
                         .font(.caption)
-                        .foregroundStyle(streak > 0 ? .orange : .secondary)
+                        .foregroundStyle(.secondary)
+                    Text(goal.kind.displayName)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
                 }
 
-                if progress >= 1 {
-                    Text("Goal complete! Keep the streak alive.")
-                        .font(.caption2)
-                        .foregroundStyle(.yellow)
-                        .padding(.top, 4)
-                }
+                Spacer()
+
+                GoalProgressRing(progress: clampedProgress, label: progressText)
             }
 
-            Spacer()
+            RunnerProgressTrack(progress: clampedProgress)
+
+            VStack(alignment: .leading, spacing: 12) {
+                GoalMetricRow(icon: "figure.run", title: "Completed", value: mileageSummary)
+
+                GoalMetricRow(icon: "flag.checkered", title: "Remaining", value: remainingMiles)
+
+                GoalMetricRow(
+                    icon: "flame.fill",
+                    title: "Streak",
+                    value: streakText,
+                    valueTint: streak > 0 ? .orange : .secondary.opacity(0.8)
+                )
+            }
+
+            if clampedProgress >= 1 {
+                Label("Goal complete! Keep the streak alive.", systemImage: "sparkles")
+                    .font(.caption2)
+                    .foregroundStyle(.yellow)
+            }
         }
-        .padding()
+        .padding(20)
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color(.systemGray6))
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .stroke(Color(.systemGray4).opacity(0.35))
+                )
         )
     }
 }
@@ -377,30 +404,49 @@ struct GoalProgressRing: View {
     let progress: Double
     let label: String
 
-    private var normalizedProgress: Double {
-        min(max(progress, 0), 1)
-    }
-
     var body: some View {
         ZStack {
             Circle()
-                .stroke(Color(.systemGray5), lineWidth: 10)
+                .strokeBorder(Color(.systemGray4).opacity(0.4), lineWidth: 8)
             Circle()
-                .trim(from: 0, to: normalizedProgress)
+                .trim(from: 0, to: progress)
                 .stroke(
-                    .linearGradient(
-                        colors: [.yellow.opacity(0.8), .yellow],
-                        startPoint: .top,
-                        endPoint: .bottom
+                    .angularGradient(
+                        colors: [.yellow.opacity(0.9), .yellow, .orange.opacity(0.9)],
+                        center: .center
                     ),
-                    style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                    style: StrokeStyle(lineWidth: 8, lineCap: .round)
                 )
                 .rotationEffect(.degrees(-90))
             Text(label)
-                .font(.caption)
+                .font(.caption.monospacedDigit())
                 .bold()
         }
-        .frame(width: 80, height: 80)
+        .frame(width: 74, height: 74)
+    }
+}
+
+struct GoalMetricRow: View {
+    let icon: String
+    let title: String
+    let value: String
+    var valueTint: Color = .primary
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(.yellow)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(valueTint)
+            }
+        }
     }
 }
 

--- a/ExtraMile+/ContentView.swift
+++ b/ExtraMile+/ContentView.swift
@@ -335,7 +335,7 @@ struct GoalProgressRow: View {
         HStack(alignment: .top, spacing: 16) {
             GoalProgressRing(progress: progress, label: progressText)
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 8) {
                 Text(goal.title)
                     .font(.headline)
                 Text(goal.intervalDescription)
@@ -344,6 +344,8 @@ struct GoalProgressRow: View {
                 Text(goal.kind.displayName)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+
+                RunnerProgressTrack(progress: progress)
 
                 VStack(alignment: .leading, spacing: 4) {
                     Label("\(String(format: "%.2f", milesCompleted)) / \(String(format: "%.2f", goal.targetMiles)) mi", systemImage: "figure.run")
@@ -399,6 +401,38 @@ struct GoalProgressRing: View {
                 .bold()
         }
         .frame(width: 80, height: 80)
+    }
+}
+
+struct RunnerProgressTrack: View {
+    let progress: Double
+
+    private let trackLength = 50
+
+    private var clampedProgress: Double {
+        min(max(progress, 0), 1)
+    }
+
+    private var leadingDots: Int {
+        Int((clampedProgress * Double(trackLength)).rounded())
+    }
+
+    private var trailingDots: Int {
+        max(trackLength - leadingDots, 0)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(String(repeating: ".", count: leadingDots))
+            Text(Image(systemName: "figure.run"))
+                .padding(.horizontal, 2)
+            Text(String(repeating: ".", count: trailingDots))
+            Text(Image(systemName: "rectangle.checkered"))
+                .padding(.leading, 2)
+        }
+        .font(.caption.monospaced())
+        .foregroundStyle(.yellow)
+        .animation(.easeInOut(duration: 0.4), value: leadingDots)
     }
 }
 

--- a/ExtraMile+/ExtraMileApp.swift
+++ b/ExtraMile+/ExtraMileApp.swift
@@ -16,6 +16,7 @@ struct ExtraMileApp: App {
     @AppStorage("lastVersion") private var lastVersion: String = ""
     
     var fbManager = FirebaseManager()
+    var goalStore = GoalStore()
     
     init() {
         if FirebaseApp.app() == nil {
@@ -29,6 +30,7 @@ struct ExtraMileApp: App {
                 if loginStatus {
                     ContentView()
                         .environment(fbManager)
+                        .environment(goalStore)
                 } else {
                     Login()
                 }


### PR DESCRIPTION
## Summary
- add persistent GoalStore and goal models so runners can track multiple targets concurrently
- refresh the dashboard to show goal-specific progress rings, streaks, and management controls
- provide a GoalEditor sheet for creating yearly, monthly, or custom race goals with sensible defaults

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb1ef4d0108320983351477aab7bce